### PR TITLE
Add labels for instance name and index

### DIFF
--- a/collectors/service_discovery_collector_test.go
+++ b/collectors/service_discovery_collector_test.go
@@ -120,7 +120,7 @@ var _ = Describe("ServiceDiscoveryCollector", func() {
 			jobAZ               = "fake-job-az"
 			jobIP               = "1.2.3.4"
 			jobProcessName      = "fake-process-name"
-			targetGroupsContent = "[{\"targets\":[\"1.2.3.4\"],\"labels\":{\"__meta_bosh_job_process_name\":\"fake-process-name\"}}]"
+			targetGroupsContent = "[{\"targets\":[\"1.2.3.4\"],\"labels\":{\"__meta_bosh_job_instance_index\":\"0\",\"__meta_bosh_job_instance_name\":\"fake-job-name\",\"__meta_bosh_job_process_name\":\"fake-process-name\"}}]"
 
 			processes       []deployments.Process
 			instances       []deployments.Instance


### PR DESCRIPTION
Orange internal review prior to offer PR to the CF community

---
This pull request adds labels for instance name and index in the `file_sd_configs` generated file.

This allows configurations like the following that renames the Prometheus instance to look like the way the BOSH cli would display it:

```yaml
- job_name: haproxy
  file_sd_configs:
    - files:
      - /var/vcap/store/bosh_exporter/bosh_target_groups.json
  relabel_configs:
    - source_labels: [__meta_bosh_job_process_name]
      regex: haproxy_exporter
      action: keep
    - source_labels: [__meta_bosh_job_instance_name,__meta_bosh_job_instance_index]
      separator: "/"
      target_label: instance
    - source_labels: [__address__]
      target_label: __address__
      replacement: "${1}:9101"
```

If users don't use these new labels in their Prometheus configuration, it shouldn't change anything for them.

These two labels cover our current needs. Maybe there are other useful labels that could be added?
